### PR TITLE
fix: ASM-34 Inconsistent Asset Assignment Status in Asset List API

### DIFF
--- a/assets/api_views.py
+++ b/assets/api_views.py
@@ -41,6 +41,8 @@ from common.pagination import add_pagination
 
 from notifications.models import UserNotification
 
+from .services import unassign_asset_from_list
+
 # @api_view(['GET'])
 # @permission_classes([IsAuthenticated])
 # def get_push_notification(request):
@@ -453,8 +455,9 @@ class UnAssignAsset(APIView):
 
     def post(self, request, id):
         get_asset = get_object_or_404(Asset, pk=id)
-        get_asset.is_assigned = False
-        get_asset.save()
+        unassign_asset_from_list(
+            asset_id=get_asset.id, organization=request.user.organization
+        )
         return api_response(status=200, message="asset unassigned successfully")
 
 


### PR DESCRIPTION
---
name: "fix/ASM-34"
about: "Fixes inconsistent asset assignment status in Asset List API"
title: "Inconsistent Asset Assignment Status in Asset List API"
---

# 🧩 Pull Request Template

## Description
Fix the UnAssignAsset REST API to use the same unassignment procedure that is provided in the Asset List page.

## Type of Change
<!-- Select one -->
- [ x] Bug Fix
- [ ] New Feature
- [ ] Enhancement / Improvement
- [ ] Documentation Update
- [ ] Refactor / Code Cleanup

## Related Issue
If this PR addresses a specific issue, link it here
- Closes # (issue number)

## Checklist
- [x ] I have read the **Code of Conduct** and followed it in this PR
- [ ] My code follows the project style and conventions
- [ ] I have added unit tests where applicable
- [ ] All new and existing tests pass
- [ ] I have updated documentation if necessary

## Screenshots / Recordings (Optional)

## Additional Notes
